### PR TITLE
Update Client.cs

### DIFF
--- a/src/RestClient.Net/Client.cs
+++ b/src/RestClient.Net/Client.cs
@@ -155,7 +155,7 @@ namespace RestClient.Net
             {
                 //Use a shared instance for serialization. There should be no reason that this is not thread safe. Unless it's not.
                 SerializationAdapter = JsonSerializationAdapter.Instance;
-                DefaultRequestHeaders = DefaultRequestHeaders.WithJsonContentTypeHeader();
+                DefaultRequestHeaders = defaultRequestHeaders ?? DefaultRequestHeaders.WithJsonContentTypeHeader();
             }
             else
             {


### PR DESCRIPTION
In constructor if serializationAdapter is null DefaultRequestHeaders are always overwritten, also if not null